### PR TITLE
Fix Planet Translation and Camera FOV

### DIFF
--- a/portfolio-website/src/components/home/InfiniteScrollContainer.tsx
+++ b/portfolio-website/src/components/home/InfiniteScrollContainer.tsx
@@ -42,7 +42,7 @@ export const InfiniteScrollContainer = ({}: Props) => {
   //endregion
   const [camera, setCamera] = useState<THREE.PerspectiveCamera>(
     new THREE.PerspectiveCamera(
-      100,
+      50,
       window.innerWidth / window.innerHeight,
       0.1,
       1000

--- a/portfolio-website/src/utils/hooks/useThreeSceneMount.tsx
+++ b/portfolio-website/src/utils/hooks/useThreeSceneMount.tsx
@@ -8,7 +8,7 @@ export const useThreeSceneMount = (canvasRef, earth) => {
   useEffect(() => {
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(
-      100,
+      50,
       window.innerWidth / window.innerHeight,
       0.1,
       1000

--- a/portfolio-website/src/utils/hooks/useThreeSceneMount.tsx
+++ b/portfolio-website/src/utils/hooks/useThreeSceneMount.tsx
@@ -70,13 +70,28 @@ export const useThreeSceneMount = (canvasRef, earth) => {
     // Animation loop or initial render
     const animate = () => {
       requestAnimationFrame(animate);
-      // Update objects' states here
+
+      // spin
       earth.rotation.y += 0.0005;
 
+      // scroll-based movement
+      const scrollTop = window.scrollY || window.pageYOffset;
+      const maxScroll = Math.max(
+        1,
+        document.documentElement.scrollHeight - window.innerHeight
+      );
+      const progress = scrollTop / maxScroll;
+      const startMove = 0.9;
+      let t = (progress - startMove) / (1 - startMove);
+      t = THREE.MathUtils.clamp(t, 0, 1);
+      const startX = -75;
+      const endX = 400; // adjust if planet doesn’t fully leave screen
+      earth.position.x = THREE.MathUtils.lerp(startX, endX, t);
+  
       controls.update();
-
       renderer.render(scene, camera);
     };
+   
     animate();
 
     // Optional: Resize listener for responsive canvas


### PR DESCRIPTION
<img width="1914" height="917" alt="image" src="https://github.com/user-attachments/assets/2664944c-3393-4ff9-a335-7cd9336952a2" />

Viewing the website on a computer, the planet looks a little more wide and it's translation doesn't go all through the page x-axis. 
I believe this have something to do with the screen size of the viewer, but the only thing I needed to fix is the camera FOV (which makes the planet a little wider) and the animate function.